### PR TITLE
fix: not loading plugins config while getting configs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Alibaba Group Holding Limited and other contributors.
+Copyright (c) 2017-present Alibaba Group Holding Limited and other contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -28,6 +28,7 @@ exports.getLoadUnits = opt => {
 
 exports.getConfig = opt => {
   const loader = getLoader(opt);
+  loader.loadPlugin();
   loader.loadConfig();
   return loader.config;
 };

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -149,7 +149,7 @@ describe('test/plugin.test.js', () => {
       });
       yield coffee.fork(bin, [ args ], { cwd: tmp })
         .debug()
-        .expect('stdout', /get app configs env,name,keys,proxy,protocolHeaders,ipHeaders,hostHeaders,pkg,baseDir,HOME,rundir,dump,notfound,siteFile,bodyParser,logger,httpclient,coreMiddleware,jsonp,workerStartTimeout,coreMiddlewares,appMiddlewares,appMiddleware/)
+        .expect('stdout', /get app configs session,security,helper,jsonp,onerror,i18n,watcher,multipart,logrotator,static,view,env,name,keys,proxy,protocolHeaders,ipHeaders,hostHeaders,pkg,baseDir,HOME,rundir,dump,notfound,siteFile,bodyParser,logger,httpclient,coreMiddleware,workerStartTimeout,coreMiddlewares,appMiddlewares,appMiddleware/)
         .expect('code', 0)
         .end();
     });
@@ -163,7 +163,7 @@ describe('test/plugin.test.js', () => {
       });
       yield coffee.fork(bin, [ args ], { cwd: tmp })
         .debug()
-        .expect('stdout', /get app configs env,name,keys,proxy,protocolHeaders,ipHeaders,hostHeaders,pkg,baseDir,HOME,rundir,dump,notfound,siteFile,bodyParser,logger,httpclient,coreMiddleware,jsonp,workerStartTimeout,coreMiddlewares,appMiddlewares,appMiddleware/)
+        .expect('stdout', /get app configs session,security,helper,jsonp,onerror,i18n,watcher,multipart,logrotator,static,view,env,name,keys,proxy,protocolHeaders,ipHeaders,hostHeaders,pkg,baseDir,HOME,rundir,dump,notfound,siteFile,bodyParser,logger,httpclient,coreMiddleware,workerStartTimeout,coreMiddlewares,appMiddlewares,appMiddleware/)
         .expect('code', 0)
         .end();
     });


### PR DESCRIPTION
Current egg-utils won't get plugins configuration while calling `utils.getConfig(...)`.