### PR TITLE
fix: scope package resolve logic in monorepo

### DIFF
--- a/src/framework.ts
+++ b/src/framework.ts
@@ -62,7 +62,19 @@ function assertAndReturn(frameworkName: string, moduleDir: string) {
   ]);
   try {
     // find framework from global, especially for monorepo
-    const globalModuleDir = path.join(require.resolve(`${frameworkName}/package.json`), '../..');
+    let globalModuleDir;
+    // if frameworkName is scoped package, like @ali/egg
+    if (frameworkName.startsWith('@') && frameworkName.includes('/')) {
+      globalModuleDir = path.join(
+        require.resolve(`${frameworkName}/package.json`),
+        '../../..',
+      );
+    } else {
+      globalModuleDir = path.join(
+        require.resolve(`${frameworkName}/package.json`),
+        '../..',
+      );
+    }
     moduleDirs.add(globalModuleDir);
   } catch (err) {
     // ignore


### PR DESCRIPTION
When frameworkName is like @ali/egg, globalModuleDir will resolve a result like xxx/@ali/. After that do path.join with frameworkName, we get xxx/@ali/@ali/egg, it's an error path.
 So, we need to fix the resolving logic for the scoped package situation