### PR TITLE
fix: set default require.resolve paths to cwd

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,6 @@ jobs:
     name: Node.js
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
-      version: '18.19.0, 18, 20, 22'
+      version: '18.19.0, 18, 20, 22, 23'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/import.ts
+++ b/src/import.ts
@@ -2,7 +2,7 @@ import { debuglog } from 'node:util';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 
-const debug = debuglog('@eggjs/utils:loader');
+const debug = debuglog('@eggjs/utils:import');
 
 let _customRequire: NodeRequire;
 
@@ -16,14 +16,18 @@ export interface ImportModuleOptions extends ImportResolveOptions {
 }
 
 export function importResolve(filepath: string, options?: ImportResolveOptions) {
+  const cwd = process.cwd();
   if (!_customRequire) {
     if (typeof require !== 'undefined') {
       _customRequire = require;
     } else {
-      _customRequire = createRequire(process.cwd());
+      _customRequire = createRequire(cwd);
     }
   }
-  const moduleFilePath = _customRequire.resolve(filepath, options);
+  const paths = options?.paths ?? [ cwd ];
+  const moduleFilePath = _customRequire.resolve(filepath, {
+    paths,
+  });
   debug('[importResolve] %o, options: %o => %o', filepath, options, moduleFilePath);
   return moduleFilePath;
 }

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -16,7 +16,12 @@ describe('test/import.test.ts', () => {
   describe('importModule()', () => {
     it('should work on cjs', async () => {
       let obj = await importModule(getFilepath('cjs'));
-      assert.deepEqual(Object.keys(obj), [ 'default', 'one' ]);
+      if (process.version.startsWith('v23.')) {
+        // support `module.exports` on Node.js >=23
+        assert.deepEqual(Object.keys(obj), [ 'default', 'module.exports', 'one' ]);
+      } else {
+        assert.deepEqual(Object.keys(obj), [ 'default', 'one' ]);
+      }
       assert.equal(obj.one, 1);
       assert.deepEqual(obj.default, { foo: 'bar', one: 1 });
 
@@ -24,19 +29,34 @@ describe('test/import.test.ts', () => {
       assert.deepEqual(obj, { foo: 'bar', one: 1 });
 
       obj = await importModule(getFilepath('cjs/exports'));
-      assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'one' ]);
+      if (process.version.startsWith('v23.')) {
+        // support `module.exports` on Node.js >=23
+        assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'module.exports', 'one' ]);
+      } else {
+        assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'one' ]);
+      }
       assert.equal(obj.foo, 'bar');
       assert.equal(obj.one, 1);
       assert.deepEqual(obj.default, { foo: 'bar', one: 1 });
 
       obj = await importModule(getFilepath('cjs/exports.js'));
-      assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'one' ]);
+      if (process.version.startsWith('v23.')) {
+        // support `module.exports` on Node.js >=23
+        assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'module.exports', 'one' ]);
+      } else {
+        assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'one' ]);
+      }
       assert.equal(obj.foo, 'bar');
       assert.equal(obj.one, 1);
       assert.deepEqual(obj.default, { foo: 'bar', one: 1 });
 
       obj = await importModule(getFilepath('cjs/exports.cjs'));
-      assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'one' ]);
+      if (process.version.startsWith('v23.')) {
+        // support `module.exports` on Node.js >=23
+        assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'module.exports', 'one' ]);
+      } else {
+        assert.deepEqual(Object.keys(obj), [ 'default', 'foo', 'one' ]);
+      }
       assert.equal(obj.foo, 'bar');
       assert.equal(obj.one, 1);
       assert.deepEqual(obj.default, { foo: 'bar', one: 1 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging clarity for the import process.
	- Enhanced handling of module resolution paths.

- **Chores**
	- Updated Node.js CI job to support an additional version for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->